### PR TITLE
Tt 2759 - file_fixtures backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## Unreleased
 ### Added
 - [TT-1392] Changelog file
+- [TT-2759] Backport rails file_fixture method

--- a/lib/rails_4_backports.rb
+++ b/lib/rails_4_backports.rb
@@ -8,6 +8,8 @@ module Rails4Backports
     end
   end
 
+  require 'rails_4_backports/file_fixtures'
+
   if defined?(Rails)
     class Railtie < ::Rails::Railtie
       config.before_initialize do |app|

--- a/lib/rails_4_backports.rb
+++ b/lib/rails_4_backports.rb
@@ -1,15 +1,19 @@
 require "rails_4_backports/version"
 
 module Rails4Backports
-  require 'rails_4_backports/active_record_dynamic_finders'
-  if ::ActiveRecord::VERSION::MAJOR == 3
-    ActiveRecord::Base.send(:extend, ActiveRecordDynamicFinders)
+  if defined?(ActiveRecord)
+    require 'rails_4_backports/active_record_dynamic_finders'
+    if ::ActiveRecord::VERSION::MAJOR == 3
+      ActiveRecord::Base.send(:extend, ActiveRecordDynamicFinders)
+    end
   end
 
-  class Railtie < ::Rails::Railtie
-    config.before_initialize do |app|
-      require 'rails-secrets'
-      app.config.secret_token ||= app.secrets.secret_key_base
+  if defined?(Rails)
+    class Railtie < ::Rails::Railtie
+      config.before_initialize do |app|
+        require 'rails-secrets'
+        app.config.secret_token ||= app.secrets.secret_key_base
+      end
     end
   end
 end

--- a/lib/rails_4_backports/file_fixtures.rb
+++ b/lib/rails_4_backports/file_fixtures.rb
@@ -1,0 +1,38 @@
+# Methods backported from Rails 5:
+# http://api.rubyonrails.org/classes/ActiveSupport/Testing/FileFixtures.html
+module Rails4Backports
+  module Testing
+    # Adds simple access to sample files called file fixtures.
+    # File fixtures are normal files stored in
+    # <tt>ActiveSupport::TestCase.file_fixture_path</tt>.
+    #
+    # File fixtures are represented as +Pathname+ objects.
+    # This makes it easy to extract specific information:
+    #
+    #   file_fixture("example.txt").read # get the file's content
+    #   file_fixture("example.mp3").size # get the file size
+    module FileFixtures
+      def self.file_fixture_path=(path)
+        @path = path
+      end
+
+      def self.file_fixture_path
+        @path
+      end
+
+      # Returns a +Pathname+ to the fixture file named +fixture_name+.
+      #
+      # Raises +ArgumentError+ if +fixture_name+ can't be found.
+      def self.file_fixture(fixture_name)
+        path = Pathname.new(File.join(file_fixture_path, fixture_name))
+
+        if path.exist?
+          path
+        else
+          msg = "the directory '%s' does not contain a file named '%s'"
+          raise ArgumentError, msg % [file_fixture_path, fixture_name]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Backports the http://api.rubyonrails.org/classes/ActiveSupport/Testing/FileFixtures.html method from Rails5, which can than be used in rspec https://relishapp.com/rspec/rspec-rails/v/3-5/docs/file-fixture